### PR TITLE
Initial prototype terraform

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.terraform
+terraform.tfstate*
+*.pem
+secrets.*

--- a/acl.tf
+++ b/acl.tf
@@ -1,0 +1,38 @@
+resource "aws_network_acl" "sg_loci" {
+  vpc_id = "${aws_vpc.loci-vpc.id}"
+  subnet_ids = ["${aws_subnet.loci-subnet-public.id}"]
+}
+resource "aws_network_acl_rule" "loci-test-acl-ingress" {
+  network_acl_id = "${aws_network_acl.sg_loci.id}"
+  egress = false
+    protocol   = "-1"
+    rule_number    = "1"
+    rule_action     = "allow"
+    cidr_block = "0.0.0.0/0" 
+}
+resource "aws_network_acl_rule" "loci-test-acl-egress" {
+  network_acl_id = "${aws_network_acl.sg_loci.id}"
+  egress = true 
+    protocol   = "-1"
+    rule_number    = "1"
+    rule_action     = "allow"
+    cidr_block = "0.0.0.0/0" 
+}
+resource "aws_network_acl_rule" "loci-test-acl-ingress-6" {
+  network_acl_id = "${aws_network_acl.sg_loci.id}"
+  egress = false
+    protocol   = "-1"
+    rule_number    = "10"
+    rule_action     = "allow"
+    ipv6_cidr_block= "::/0"
+}
+resource "aws_network_acl_rule" "loci-test-acl-egress-6" {
+  network_acl_id = "${aws_network_acl.sg_loci.id}"
+  egress = true 
+    protocol   = "-1"
+    rule_number    = "10"
+    rule_action     = "allow"
+    ipv6_cidr_block= "::/0"
+}
+
+

--- a/ec2-gateway.tf
+++ b/ec2-gateway.tf
@@ -1,0 +1,51 @@
+resource "aws_instance" "test_loci_ec2" {
+  ami           = "ami-075caa3491def750b"
+  instance_type = "t2.micro"
+  subnet_id = "${aws_subnet.loci-subnet-public.id}"
+  key_name = "${aws_key_pair.ec2key.key_name}"
+  vpc_security_group_ids = ["${aws_security_group.loci-ec2.id}"]
+  tags = {
+    Name    = "loci test gateway"
+    Project = "Loci"
+    O2D     = "TBA"
+    }
+}
+resource "aws_key_pair" "ec2key" {
+  key_name = "publicKey"
+  public_key = "${file(var.public_key_path)}"
+}
+
+resource "aws_security_group" "loci-ec2" {
+  name        = "loci_ec2"
+  description = "loci_ec2 security group"
+  vpc_id = "${aws_vpc.loci-vpc.id}"
+
+  ingress {
+    # TLS (change to whatever ports you need)
+    from_port   = 22 
+    to_port     = 22 
+    protocol    = "tcp"
+    cidr_blocks = "${var.cidr}"
+  }
+  ingress {
+    # TLS (change to whatever ports you need)
+    from_port   = 22 
+    to_port     = 22 
+    protocol    = "tcp"
+    ipv6_cidr_blocks = "${var.ipv6_cidr}"
+  }
+
+  egress {
+    from_port       = 0
+    to_port         = 0
+    protocol        = "-1"
+    cidr_blocks     = ["0.0.0.0/0"]
+  }
+  egress {
+    from_port       = 0
+    to_port         = 0
+    protocol        = "-1"
+    ipv6_cidr_blocks     = ["::/0"]
+  }
+}
+

--- a/region.tf
+++ b/region.tf
@@ -1,0 +1,3 @@
+provider "aws" {
+  region = "ap-southeast-2"
+}

--- a/secrets_template
+++ b/secrets_template
@@ -1,0 +1,8 @@
+variable "ipv6_cidr" {
+    type = "list"
+    default = ["00::/0", "00::/0"]
+}
+variable "cidr" {
+    type = "list"
+    default = ["0.0.0.0/0", "0.0.0.0/0"]
+}

--- a/variables.tf
+++ b/variables.tf
@@ -1,0 +1,29 @@
+
+variable "cidr_vpc" {
+  description = "CIDR block for the VPC"
+  default = "10.0.0.0/16"
+}
+variable "cidr_subnet" {
+  description = "CIDR block for the subnet"
+  default = "10.0.0.0/24"
+}
+variable "availability_zone" {
+  description = "availability zone to create subnet"
+  default = "ap-southeast-2c"
+}
+variable "public_key_path" {
+  description = "Public key path"
+  default = "~/.ssh/id_rsa.pub"
+}
+variable "instance_ami" {
+  description = "AMI for aws EC2 instance"
+  default = "ami-0cf31d971a3ca20d6"
+}
+variable "instance_type" {
+  description = "type for aws EC2 instance"
+  default = "t2.micro"
+}
+variable "environment_tag" {
+  description = "Environment tag"
+  default = "Production"
+}

--- a/vpc.tf
+++ b/vpc.tf
@@ -1,0 +1,53 @@
+resource "aws_vpc" "loci-vpc" {
+  cidr_block       = "10.0.0.0/16"
+  enable_dns_support = true
+  enable_dns_hostnames = true
+
+  tags = {
+    Name    = "loci test vpc"
+    Project = "Loci"
+    O2D     = "TBA"
+  }
+}
+resource "aws_internet_gateway" "loci-igw" {
+  vpc_id = "${aws_vpc.loci-vpc.id}"
+  tags = {
+    Name    = "loci test igw"
+    Project = "Loci"
+    O2D     = "TBA"
+  }
+}
+
+resource "aws_subnet" "loci-subnet-public" {
+  vpc_id = "${aws_vpc.loci-vpc.id}"
+  cidr_block = "10.0.0.0/24"
+  map_public_ip_on_launch = "true"
+  availability_zone = "${var.availability_zone}"
+  tags = {
+    Name    = "loci test subnet"
+    Project = "Loci"
+    O2D     = "TBA"
+  }
+}
+resource "aws_route_table" "loci-rtb-public" {
+  vpc_id = "${aws_vpc.loci-vpc.id}"
+  route {
+      cidr_block = "0.0.0.0/0"
+      gateway_id = "${aws_internet_gateway.loci-igw.id}"
+  }
+  tags = {
+    Name    = "loci test route table"
+    Project = "Loci"
+    O2D     = "TBA"
+  }
+}
+
+resource "aws_route_table_association" "loci-rta-subnet-public" {
+  subnet_id      = "${aws_subnet.loci-subnet-public.id}"
+  route_table_id = "${aws_route_table.loci-rtb-public.id}"
+}
+
+resource "aws_main_route_table_association" "loci-main-table" {
+  vpc_id         = "${aws_vpc.loci-vpc.id}"
+  route_table_id = "${aws_route_table.loci-rtb-public.id}"
+}


### PR DESCRIPTION
This is an initial prototype demonstrating how to use terraform to setup AWS base level infrastructure the aim is to:

1) document loci AWS infrastructure as code
2) improve security and meet CSIRO IMT requirements internally
3) potentially provide a basis for partner organizations to spin up similar infrastructures

so far this demonstrates VPC, Subnet, Internet Gateway, EC2, and IP restricted security groups

you should be able to test this locally against our AWS account