### PR TITLE
Add SSL configs to packer builds

### DIFF
--- a/packer/loci-geometry-data-service/loci-geometry-data-service-image.json
+++ b/packer/loci-geometry-data-service/loci-geometry-data-service-image.json
@@ -35,6 +35,16 @@
       "destination": "/tmp/instance.sh"
     },
     {
+      "type": "file",
+      "source": "../certs/wildcard-loci-cat.pem",
+      "destination": "/tmp/wildcard-loci-cat.pem"
+    },
+    {
+      "type": "file",
+      "source": "../certs/wildcard-loci-cat.bundle.pem",
+      "destination": "/tmp/wildcard-loci-cat.bundle.pem"
+    },
+    {
       "type": "shell",
       "script": "./prov.sh",
       "environment_vars": [ 

--- a/packer/loci-geometry-data-service/prov.sh
+++ b/packer/loci-geometry-data-service/prov.sh
@@ -7,11 +7,14 @@ chmod +x /usr/bin/docker-compose
 systemctl enable docker
 systemctl start docker && sleep 5
 usermod -a -G docker ec2-user
-git clone --single-branch --branch master https://github.com/CSIRO-enviro-informatics/loci-geometry-data-service.git
+git clone --single-branch --branch prod https://github.com/CSIRO-enviro-informatics/loci-geometry-data-service.git
 mv /tmp/instance.sh  /var/lib/cloud/scripts/per-instance/instance.sh
 chmod +x /var/lib/cloud/scripts/per-instance/instance.sh
 printenv
 echo -e "GSDB_HOSTNAME=10.0.1.201" > /home/ec2-user/loci-geometry-data-service/.env
 echo -e "GSDB_PORT=25432" >> /home/ec2-user/loci-geometry-data-service/.env
 echo -e "PORT=80" >> /home/ec2-user/loci-geometry-data-service/.env
-cd /home/ec2-user/loci-geometry-data-service/ && pwd && ls && docker-compose -f docker-compose.yml up -d gservice
+mv /tmp/wildcard-loci-cat.bundle.pem /home/ec2-user/loci-geometry-data-service/certs/
+mv /tmp/wildcard-loci-cat.pem /home/ec2-user/loci-geometry-data-service/certs/
+ls -la /home/ec2-user/loci-geometry-data-service/certs/ 
+cd /home/ec2-user/loci-geometry-data-service/ && pwd && ls && docker-compose -f docker-compose.yml -f docker-compose.prod.yml up -d gservice caddy

--- a/packer/loci-integration-api/loci-integration-api-image.json
+++ b/packer/loci-integration-api/loci-integration-api-image.json
@@ -30,6 +30,16 @@
         "destination": "/tmp/instance.sh"
       },
       {
+         "type": "file",
+         "source": "../certs/wildcard-loci-cat.pem",
+         "destination": "/tmp/wildcard-loci-cat.pem"
+      },
+      {
+         "type": "file",
+         "source": "../certs/wildcard-loci-cat.bundle.pem",
+         "destination": "/tmp/wildcard-loci-cat.bundle.pem"
+      },
+      {
         "type": "shell",
         "script": "./prov.sh", 
         "execute_command": "echo 'packer' | sudo -S sh -c '{{ .Vars }} {{ .Path }}'" 

--- a/packer/loci-integration-api/prov.sh
+++ b/packer/loci-integration-api/prov.sh
@@ -10,4 +10,7 @@ echo "vm.max_map_count=262144" >> /etc/sysctl.d/98-sysctl.conf
 usermod -a -G docker ec2-user
 git clone --single-branch --branch prod https://github.com/CSIRO-enviro-informatics/loci-integration-api.git 
 mv /tmp/instance.sh  /var/lib/cloud/scripts/per-instance/instance.sh
+mv /tmp/wildcard-loci-cat.bundle.pem /home/ec2-user/loci-integration-api/certs/
+mv /tmp/wildcard-loci-cat.pem /home/ec2-user/loci-integration-api/certs/
+ls -la /home/ec2-user/loci-integration-api/certs/
 chmod +x /var/lib/cloud/scripts/per-instance/instance.sh


### PR DESCRIPTION
This PR adds code in scripts and packer to use local ssl certs for the loci-integration-api and loci-geometry-data-service.