### PR TITLE
Bind to DGGS env in loci-integration-api

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 terraform.tfstate*
 *.pem
 secrets.*
+*.env

--- a/packer/loci-integration-api/envs/README.md
+++ b/packer/loci-integration-api/envs/README.md
@@ -1,0 +1,2 @@
+Add .env files here for loci-integration-api. 
+These may contain secrets and other environment variables for docker-compose.

--- a/packer/loci-integration-api/loci-integration-api-image.json
+++ b/packer/loci-integration-api/loci-integration-api-image.json
@@ -12,10 +12,10 @@
     "instance_type": "t2.micro",
     "force_deregister" : true,
     "force_delete_snapshot" : true,
-    "tags": { "purpose": "loci-integration-api-image-test {{timestamp}}" } ,
-    "run_volume_tags": { "purpose": "run loci-integration-api-image-test {{timestamp}}" } ,
+    "tags": { "purpose": "loci-integration-api-image {{timestamp}}" } ,
+    "run_volume_tags": { "purpose": "run loci-integration-api-image {{timestamp}}" } ,
     "ssh_username": "ec2-user",
-    "ami_name": "loci-integration-api-image-test {{timestamp}}",
+    "ami_name": "loci-integration-api-image {{timestamp}}",
     "launch_block_device_mappings": [{
       "device_name": "/dev/xvda",
       "delete_on_termination": true,
@@ -38,6 +38,11 @@
          "type": "file",
          "source": "../certs/wildcard-loci-cat.bundle.pem",
          "destination": "/tmp/wildcard-loci-cat.bundle.pem"
+      },
+      {
+         "type": "file",
+         "source": "./envs/api_with_dggs_credentials.env",
+         "destination": "/tmp/api_with_dggs_credentials.env"
       },
       {
         "type": "shell",

--- a/packer/loci-integration-api/prov.sh
+++ b/packer/loci-integration-api/prov.sh
@@ -12,5 +12,6 @@ git clone --single-branch --branch prod https://github.com/CSIRO-enviro-informat
 mv /tmp/instance.sh  /instance.sh
 mv /tmp/wildcard-loci-cat.bundle.pem /home/ec2-user/loci-integration-api/certs/
 mv /tmp/wildcard-loci-cat.pem /home/ec2-user/loci-integration-api/certs/
+[ -f /tmp/api_with_dggs_credentials.env ] && mv /tmp/api_with_dggs_credentials.env /home/ec2-user/loci-integration-api/.env
 ls -la /home/ec2-user/loci-integration-api/certs/
 chmod +x /instance.sh


### PR DESCRIPTION
First stab at how to include a `.env` file to configure loci-integration-api to connect to DGGS lookup DB.